### PR TITLE
Strip valid RAINER calls from script context (#21)

### DIFF
--- a/R/current_script.R
+++ b/R/current_script.R
@@ -1,17 +1,49 @@
 #' Collects the current script
 #'
-#' This function gathers the current document and formates it accordingly.
+#' This function gathers the current document and formats it accordingly.
 #'
 #' @return Nothing
-
 current_script <- function() {
+  max_chars <- 15000
+  lines_start <- 50
+  lines_before_cursor <- 200
+  lines_after_cursor <- 100
   current_script <- tryCatch(
     {
-      script_content <- rstudioapi::getSourceEditorContext()$contents
+      context <- rstudioapi::getSourceEditorContext()
+      script_content <- context$contents
+      cursor_line <- context$selection[[1]]$range$start[["row"]]
+      rainer_pattern <- "^\\s*(\\w+\\s*<-\\s*)?(rainer::)?(r_error|r_explain|r_improve|r_activate|r_export)\\s*\\("
+      script_content <- script_content[!grepl(rainer_pattern, script_content)]
       if (!is.null(script_content)) {
-        # Add line numbers to the script content
-        numbered_script <- paste0("L", seq_along(script_content), ":", script_content)
-        paste0(numbered_script, collapse = "\n")
+        total_lines <- length(script_content)
+        numbered_script <- paste0("L", seq_len(total_lines), ":", script_content)
+        if (total_lines <= lines_start + lines_before_cursor + lines_after_cursor) {
+          result <- paste0(numbered_script, collapse = "\n")
+        } else {
+          start_section <- numbered_script[1:min(lines_start, total_lines)]
+          cursor_start <- max(lines_start + 1, cursor_line - lines_before_cursor)
+          cursor_end <- min(total_lines, cursor_line + lines_after_cursor)
+          if (cursor_end >= total_lines - 50) {
+            cursor_start <- max(lines_start + 1, total_lines - lines_before_cursor - lines_after_cursor)
+          }
+          cursor_section <- numbered_script[cursor_start:cursor_end]
+          if (cursor_start > lines_start + 1) {
+            omitted <- cursor_start - lines_start - 1
+            combined <- c(
+              start_section,
+              paste0("\n...[", omitted, " lines omitted]...\n"),
+              cursor_section
+            )
+          } else {
+            combined <- c(start_section, cursor_section)
+          }
+          result <- paste0(combined, collapse = "\n")
+        }
+        if (nchar(result) > max_chars) {
+          result <- paste0(substr(result, 1, max_chars), "\n...[truncated due to character limit]...")
+        }
+        result
       } else {
         NULL
       }
@@ -20,6 +52,5 @@ current_script <- function() {
       NULL
     }
   )
-
   return(current_script)
 }

--- a/tests/testthat/test-environment_info.R
+++ b/tests/testthat/test-environment_info.R
@@ -335,3 +335,146 @@ test_that("environment_info snapshot with complex nested dataframes", {
   result <- environment_info(error = TRUE)
   expect_snapshot(result)
 })
+
+test_that("current_script returns full script when short enough", {
+  local_mocked_bindings(
+    getSourceEditorContext = function() {
+      list(
+        contents = EXAMPLE_SCRIPT,
+        selection = list(list(range = list(
+          start = structure(c(row = 10, column = 1), class = "document_position"),
+          end = structure(c(row = 10, column = 1), class = "document_position")
+        )))
+      )
+    },
+    .package = "rstudioapi"
+  )
+
+  result <- current_script()
+
+  expect_false(grepl("lines omitted", result))
+  expect_true(grepl("L1:", result))
+  expect_true(grepl("L22:", result))
+})
+
+test_that("current_script truncates long scripts using cursor position", {
+  long_script <- paste0("x_", 1:1500, " <- ", 1:1500)
+
+  local_mocked_bindings(
+    getSourceEditorContext = function() {
+      list(
+        contents = long_script,
+        selection = list(list(range = list(
+          start = structure(c(row = 750, column = 1), class = "document_position"),
+          end = structure(c(row = 750, column = 1), class = "document_position")
+        )))
+      )
+    },
+    .package = "rstudioapi"
+  )
+
+  result <- current_script()
+
+  expect_true(grepl("lines omitted", result))
+  expect_true(grepl("L1:", result))
+  expect_true(grepl("L750:", result))
+  expect_false(grepl("L200:x_200", result))
+})
+
+test_that("current_script applies character limit", {
+  long_script <- paste0(rep(paste(rep("a", 100), collapse = ""), 500), 1:500)
+
+  local_mocked_bindings(
+    getSourceEditorContext = function() {
+      list(
+        contents = long_script,
+        selection = list(list(range = list(
+          start = structure(c(row = 250, column = 1), class = "document_position"),
+          end = structure(c(row = 250, column = 1), class = "document_position")
+        )))
+      )
+    },
+    .package = "rstudioapi"
+  )
+
+  result <- current_script()
+
+  expect_true(nchar(result) <= 15100)
+  expect_true(grepl("truncated due to character limit", result))
+})
+
+test_that("current_script is better when cursor is near end of document", {
+  long_script <- paste0("x_", 1:1500, " <- ", 1:1500)
+
+  local_mocked_bindings(
+    getSourceEditorContext = function() {
+      list(
+        contents = long_script,
+        selection = list(list(range = list(
+          start = structure(c(row = 1490, column = 1), class = "document_position"),
+          end = structure(c(row = 1490, column = 1), class = "document_position")
+        )))
+      )
+    },
+    .package = "rstudioapi"
+  )
+
+  result <- current_script()
+
+  expect_true(grepl("L1490:", result))
+  expect_true(grepl("L1500:", result))
+  expect_true(grepl("lines omitted", result))
+})
+test_that("current_script removes valid rainer calls", {
+  script_with_rainer <- c(
+    "x <- 1",
+    "y <- x + z",
+    "rainer::r_error()",
+    "r_explain()",
+    "r_improve()"
+  )
+
+  local_mocked_bindings(
+    getSourceEditorContext = function() {
+      list(
+        contents = script_with_rainer,
+        selection = list(list(range = list(
+          start = structure(c(row = 2, column = 1), class = "document_position"),
+          end = structure(c(row = 2, column = 1), class = "document_position")
+        )))
+      )
+    },
+    .package = "rstudioapi"
+  )
+
+  result <- current_script()
+
+  expect_false(grepl("r_error", result))
+  expect_false(grepl("r_explain", result))
+  expect_false(grepl("r_improve", result))
+  expect_true(grepl("y <- x \\+ z", result))
+})
+test_that("current_script keeps invalid rainer calls", {
+  script_with_broken_rainer <- c(
+    "x <- 1",
+    "y <- x + z",
+    "r_error_custom()"
+  )
+
+  local_mocked_bindings(
+    getSourceEditorContext = function() {
+      list(
+        contents = script_with_broken_rainer,
+        selection = list(list(range = list(
+          start = structure(c(row = 2, column = 1), class = "document_position"),
+          end = structure(c(row = 2, column = 1), class = "document_position")
+        )))
+      )
+    },
+    .package = "rstudioapi"
+  )
+
+  result <- current_script()
+
+  expect_true(grepl("r_error_custom", result))
+})


### PR DESCRIPTION
Closes #21

## Summary
This PR prevents RAINER from identifying its own function calls as the cause of an error.

## Changes
- Added a filter in `current_script()` that strips valid RAINER calls (`r_error`, `r_explain`, `r_improve`, `r_activate`, `r_export`) from the script before sending it to the LLM
- Only valid calls are stripped, broken or custom ones (e.g. `r_error_custom()`) are kept since those could be the error

## Testing
- Added 2 new tests: one verifying valid RAINER calls are removed, one verifying invalid calls are kept
- All 110 tests passing